### PR TITLE
support __skipRender

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,16 +53,15 @@ module.exports = function (options) {
       this[key] = context[key];
     }
 
-    if (!data.__skipRender) {
+    if (data.__skipRender) {
+      yield* next;
+    } else {
       var view = data.__view;
       debug('mock %s => %j, view: %s', this.url, data, view);
       if (!view || IS_JSON_RE.test(this.path)) {
         return this.body = data;
       }
       yield this.render(view, data);
-    } else {
-      console.log(this.state)
-      yield* next;
     }
     inject(this);
   };

--- a/index.js
+++ b/index.js
@@ -53,14 +53,17 @@ module.exports = function (options) {
       this[key] = context[key];
     }
 
-    var view = data.__view;
-    debug('mock %s => %j, view: %s', this.url, data, view);
-    if (!view || IS_JSON_RE.test(this.path)) {
-      return this.body = data;
+    if (!data.__skipRender) {
+      var view = data.__view;
+      debug('mock %s => %j, view: %s', this.url, data, view);
+      if (!view || IS_JSON_RE.test(this.path)) {
+        return this.body = data;
+      }
+      yield this.render(view, data);
+    } else {
+      console.log(this.state)
+      yield* next;
     }
-
-    yield this.render(view, data);
-
     inject(this);
   };
 

--- a/test/app.js
+++ b/test/app.js
@@ -51,7 +51,14 @@ nunjucks.configure(path.join(fixtures, 'views'));
 
 app.context.render = function* (view, data) {
   var that = this;
-  data = data || '';
+  data = data || {};
+  if(this.state){
+    Object.keys(this.state).forEach(function(key){
+      if(!data.hasOwnProperty(key)){
+        data[key] = this.state[key];
+      }
+    }, this);
+  }
   data.helper = {
     getSessionId: function() {
       return that.sessionId;

--- a/test/fixtures/mocks/skipRender.js
+++ b/test/fixtures/mocks/skipRender.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'skipRender',
+  __skipRender: true,
+  __context: {
+    state: {
+      name: 'skip-render'
+    }
+  }
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,14 @@ describe('index.test.js', function () {
     .expect(/fengmk2/, done);
   });
 
+  it('should skip render when __skipRender=true', function (done) {
+    request(app.listen())
+    .get('/?__scene=skipRender')
+    .expect('x-koa-mock', 'true')
+    .expect(/iframe/)
+    .expect(/skip-render/, done);
+  });
+
   it('should also inject when __scene is not specified', function (done) {
     request(app.listen())
     .get('/users/1') // mocks/users/1/*


### PR DESCRIPTION
sometime, we use js to render pages.
when mock, we need to add `__scene` to `referer`, but don't mock the view render, only mock ajax render