### PR TITLE
feat: scenes inject into __koa_mock_scene_toolbox html

### DIFF
--- a/scene_toolbox.html
+++ b/scene_toolbox.html
@@ -49,7 +49,7 @@
         document.domain = qs.domain;
       }
       var parent = this.top;
-      var scenes = parent.__koa_mock_scenes || {};
+      var scenes = window.__koa_mock_scenes || {};
 
       var select = document.getElementById('j-switch-scene');
       var queries = parseQueryString(parent.location.search);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ describe('index.test.js', function () {
     request(app.listen())
     .get('/users/1') // mocks/users/1/*
     .expect('x-koa-mock', 'false')
-    .expect(/window.__koa_mock_scenes=/)
+    .expect(/target_uri=\/users\/1/)
     .expect(/iframe/, done);
   });
 


### PR DESCRIPTION
```
__koa_mock_scene_toolbox?domain=hostname:52 Uncaught SecurityError: Blocked a frame with origin 
"${hostname}" from accessing a frame with origin "${hostname}". The frame requesting access set 
"document.domain" to "${hostname}", but the frame being accessed did not. Both must set 
"document.domain" to the same value to allow access.
```

refactor code